### PR TITLE
Keywords in function calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Because of the function calling  syntax, you can actually define your  own pseud
 example, you could create a function which does the exact same thing as an if expression:
 
 ```
-def find whether $condition is truthy or falsey and set the result to $a or $b respectively {
+def if $condition then $a else $b {
   if (condition) {
     a;
   } else {
@@ -110,16 +110,16 @@ def find whether $condition is truthy or falsey and set the result to $a or $b r
 First things first: this is the first time you've seen an if expression in this language. They're fairly
 standard. One main difference is that they're expressions, not statements, like in some other languages.
 
-If expressions are also the reason the (very verbose) function defined above cannot contain the words
-`if`, `else`, or `elif`, or any other keyword for that matter.
-
 You can then call it like this:
 
 ```
-find whether true is truthy or falsey and set the result to 5 or 10 respectively;
+\if (true) then 5 else 10;
 ```
 
-Which, as you can probably guess, will return 5.
+Which, as you can probably guess, will return 5. A few things to mention: you need to use a
+backslash before the custom-defined if function, because otherwise it will parse it as a
+normal if expression. Also, `true` has to be in a set of parentheses because otherwise it will be
+parsed as a normal identifier in the pattern.
 
 This is really cool because, in theory, you could even define the English language as a series of functions!
 

--- a/examples/custom-if
+++ b/examples/custom-if
@@ -1,0 +1,13 @@
+def iff $condition $a else $b {
+  if (condition) {
+    run $a;
+  } else {
+    run $b;
+  };
+};
+
+iff (false) {
+  print "Hello!";
+} else {
+  print "The other one...";
+};

--- a/examples/custom-if
+++ b/examples/custom-if
@@ -1,4 +1,4 @@
-def iff $condition $a else $b {
+def if $condition $a else $b {
   if (condition) {
     run $a;
   } else {
@@ -6,7 +6,7 @@ def iff $condition $a else $b {
   };
 };
 
-iff (false) {
+\if (false) {
   print "Hello!";
 } else {
   print "The other one...";

--- a/parser.py
+++ b/parser.py
@@ -55,7 +55,7 @@ class Parser(object):
     """parses a stream of tokens into an abstract syntax tree (AST)"""
     def __init__(self, tokens):
         self.tokens   = tokens
-        self.errors  = [] # [(msg, start, end)]
+        self.errors   = [] # [(msg, start, end)]
         self.cur_tok  = None
         self.peek_tok = None
         
@@ -114,6 +114,16 @@ class Parser(object):
     def cur_precedence(self):
         return precedences.get(self.cur_tok.type, LOWEST)
         
+    def err(self, msg, start = None, end = None):
+        if start == None:
+            start = self.cur_tok.start
+            
+        if end == None:
+            end = self.cur_tok.end
+        
+        error = (msg, start, end)
+        self.errors.append(error)
+        
     def peek_err(self, t):
         if type(t) == type([]):
             msg = "expected any of [%s], but got %s" % (
@@ -139,16 +149,6 @@ class Parser(object):
     def no_prefix_fn_error(self, t):
         msg = "unexpected token: %s" % t
         self.err(msg)
-        
-    def err(self, msg, start = None, end = None):
-        if start == None:
-            start = self.cur_tok.start
-            
-        if end == None:
-            end = self.cur_tok.end
-        
-        error = (msg, start, end)
-        self.errors.append(error)
         
     def print_error(self, index = 0):
         msg, start, end = self.errors[index]
@@ -350,25 +350,24 @@ class Parser(object):
         
         while self.peek_in(arg_tokens):
             self.next()
+                
+            arg = lambda val: ast.Argument(self.cur_tok, val)
             
-            if self.cur_is(token.ID):
-                expr.pattern.append(ast.Identifier(self.cur_tok))
-            elif self.cur_is(token.LPAREN):
-                expr.pattern.append(ast.Argument(self.cur_tok, self.parse_grouped_expr()))
-            elif self.cur_is(token.NUM):
-                expr.pattern.append(ast.Argument(self.cur_tok, self.parse_num()))
-            elif self.cur_is(token.NULL):
-                expr.pattern.append(ast.Argument(self.cur_tok, self.parse_null()))
-            elif self.cur_in([token.TRUE, token.FALSE]):
-                expr.pattern.append(ast.Argument(self.cur_tok, self.parse_bool()))
-            elif self.cur_is(token.STR):
-                expr.pattern.append(ast.Argument(self.cur_tok, self.parse_string()))
-            elif self.cur_is(token.PARAM):
-                expr.pattern.append(ast.Argument(self.cur_tok, ast.Identifier(self.cur_tok)))
-            elif self.cur_is(token.LSQUARE):
-                expr.pattern.append(ast.Argument(self.cur_tok, self.parse_array()))
-            elif self.cur_is(token.LBRACE):
-                expr.pattern.append(ast.Argument(self.cur_tok, self.parse_block_literal()))
+            handlers = {
+                token.ID:      lambda: ast.Identifier(self.cur_tok),
+                token.LPAREN:  lambda: arg(self.parse_grouped_expr()),
+                token.NUM:     lambda: arg(self.parse_num()),
+                token.NULL:    lambda: arg(self.parse_null()),
+                token.TRUE:    lambda: arg(self.parse_bool()),
+                token.FALSE:   lambda: arg(self.parse_bool()),
+                token.STR:     lambda: arg(self.parse_string()),
+                token.PARAM:   lambda: arg(ast.Identifier(self.cur_tok)),
+                token.LSQUARE: lambda: arg(self.parse_array()),
+                token.LBRACE:  lambda: arg(self.parse_block_literal()),
+            }
+            
+            handler = handlers[self.cur_tok.type]
+            expr.apttern.append(handler())
                 
         if len(expr.pattern) == 0:
             self.err("expected at least one item in a pattern")


### PR DESCRIPTION
Keywords are now allowed in function calls. They work as a normal identifier would. However, this means that keyword literals, such as `true`, `false`, `yes`, `no`, and `null`, must be surrounded in parentheses so as to not be converted to identifiers too.